### PR TITLE
fix Auth provider to Google from Discord

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,6 @@ DATABASE_URL="postgresql://postgres:password@localhost:5432/awsAndT3StackApps"
 # NEXTAUTH_SECRET=""
 NEXTAUTH_URL="http://localhost:3000"
 
-# Next Auth Discord Provider
-DISCORD_CLIENT_ID=""
-DISCORD_CLIENT_SECRET=""
+# Next Auth Google Provider
+GOOGLE_CLIENT_ID=""
+GOOGLE_CLIENT_SECRET=""

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ graph TD
 
 ## 4. Authentication Setup
 
-- [ ] Configure NextAuth.js
-- [ ] Set up required authentication providers
+- [x] Configure NextAuth.js
+- [x] Set up required authentication providers
 - [ ] Configure JWT secret
 
 ## 5. API Implementation

--- a/src/env.js
+++ b/src/env.js
@@ -22,8 +22,8 @@ export const env = createEnv({
       // VERCEL_URL doesn't include `https` so it cant be validated as a URL
       process.env.VERCEL ? z.string() : z.string().url()
     ),
-    DISCORD_CLIENT_ID: z.string(),
-    DISCORD_CLIENT_SECRET: z.string(),
+    GOOGLE_CLIENT_ID: z.string(),
+    GOOGLE_CLIENT_SECRET: z.string(),
   },
 
   /**
@@ -44,8 +44,8 @@ export const env = createEnv({
     NODE_ENV: process.env.NODE_ENV,
     NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
     NEXTAUTH_URL: process.env.NEXTAUTH_URL,
-    DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
-    DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
+    GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
+    GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -5,7 +5,7 @@ import {
   type NextAuthOptions,
 } from "next-auth";
 import { type Adapter } from "next-auth/adapters";
-import DiscordProvider from "next-auth/providers/discord";
+import GoogleProvider from "next-auth/providers/google";
 
 import { env } from "~/env";
 import { db } from "~/server/db";
@@ -59,9 +59,9 @@ export const authOptions: NextAuthOptions = {
     verificationTokensTable: verificationTokens,
   }) as Adapter,
   providers: [
-    DiscordProvider({
-      clientId: env.DISCORD_CLIENT_ID,
-      clientSecret: env.DISCORD_CLIENT_SECRET,
+    GoogleProvider({
+      clientId: env.GOOGLE_CLIENT_ID,
+      clientSecret: env.GOOGLE_CLIENT_SECRET,
     }),
     /**
      * ...add more providers here.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 認証プロバイダーがDiscordからGoogleに変更されました。

- **ドキュメント**
  - `.env.example`ファイルと`README.md`ファイルが更新されました。
    - GoogleのクライアントIDとクライアントシークレットが追加されました。
    - 認証セットアップのチェックリスト項目が完了済みとして更新されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->